### PR TITLE
Add events in module install step

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@gah/shared": "^0.4.2",
+    "@gah/shared": "^0.5.5",
     "chalk": "^4.1.0",
     "change-case": "^4.1.1",
     "commander": "^6.0.0",

--- a/cli/src/install-helper/gah-host-def.ts
+++ b/cli/src/install-helper/gah-host-def.ts
@@ -116,6 +116,7 @@ export class GahHostDef extends GahModuleBase {
 
     this.collectModuleScripts();
 
+    this.pluginService.triggerEvent('BEFORE_INSTALL_PACKAGES', { module: this.data() });
     this.prog('installing packages');
     if (!skipPackageInstall) {
       await this.installPackages();

--- a/cli/src/install-helper/gah-module-def.ts
+++ b/cli/src/install-helper/gah-module-def.ts
@@ -88,10 +88,14 @@ export class GahModuleDef extends GahModuleBase {
     this.gahFolder.tryHideGahFolder();
     this.prog('linking dependencies');
     await this.createSymlinksToDependencies();
+    this.pluginService.triggerEvent('SYMLINKS_CREATED', { module: this.data() });
     this.prog('referencing dependencies');
     await this.addDependenciesToTsConfigFile();
+    this.pluginService.triggerEvent('TS_CONFIG_ADJUSTED', { module: this.data() });
     this.prog('adjusting configurations');
     this.adjustGitignore();
+    this.pluginService.triggerEvent('GITIGNORE_ADJUSTED', { module: this.data() });
+    this.pluginService.triggerEvent('BEFORE_INSTALL_PACKAGES', { module: this.data() });
     this.prog('installing packages');
     if (!skipPackageInstall) {
       await this.installPackages();

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -35,10 +35,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@gah/shared@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@gah/shared/-/shared-0.4.2.tgz#44b6d33aa28b02924fc59396f25661deec69fb5a"
-  integrity sha512-y6cK1Jl9ixmEuOVQ5KGdwgqWXBkbwQWgT1zRtjyvWC5V5Eth6XGJlahk6I7ltPJY76V0u5MZezBN87kWSoDjMw==
+"@gah/shared@^0.5.5":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@gah/shared/-/shared-0.5.5.tgz#67da6ec176bb30ba55470d38e8b1048e063f2d60"
+  integrity sha512-f0zRTqZxHKip0f3gsm4xz36zUwfg7Yp5VAwz6AE4K8b9K3xi0f/mxVSXBqoRdJUFZ7hesh0KiloBWAkZIMgySg==
 
 "@kwsites/file-exists@^1.1.1":
   version "1.1.1"

--- a/shared/src/models/gah-event.ts
+++ b/shared/src/models/gah-event.ts
@@ -22,7 +22,8 @@ export type GahEvent =
   { type: 'ANGULAR_JSON_ADJUSTED', module?: GahModuleData } |
   { type: 'INDEX_HTML_ADJUSTED', module?: GahModuleData } |
   { type: 'WEB_CONFIG_ADJUSTED', module?: GahModuleData } |
-  { type: 'PACKAGES_INSTALLED', module?: GahModuleData }
+  { type: 'PACKAGES_INSTALLED', module?: GahModuleData } |
+  { type: 'BEFORE_INSTALL_PACKAGES', module?: GahModuleData } 
 
 export type GahEventType = GahEvent['type'];
 export type ExtractEventPayload<A, T> = A extends { type: T } ? A : never


### PR DESCRIPTION
To allow a plugin to subscribe to an event when installing a module, events were added during installation. Also a new event was created so that the package.json can be customized by plugins before the packages are installed.